### PR TITLE
Replace retired gather() with pivot_longer()

### DIFF
--- a/Population pyramid chart with geom_bar().R
+++ b/Population pyramid chart with geom_bar().R
@@ -7,7 +7,7 @@ data <- read.csv(url)
 head(data)
 # Manipulating data
 data <- data%>%
-  gather('Gender','Population',2:3)%>%
+  pivot_longer(names_to = 'Gender', values_to = 'Population', cols = 2:3) %>%
   mutate(PopPerc=case_when(Gender=='M'~round(Population/sum(Population)*100,2),
                            TRUE~-round(Population/sum(Population)*100,2)),
          signal=case_when(Gender=='M'~1,


### PR DESCRIPTION
The dplyr package lists gather and spread as retired functions now. 

Per the documentation:
"Development on gather() is complete, and for new code we recommend switching to pivot_longer(), which is easier to use, more featureful, and still under active development. df %>% gather("key", "value", x, y, z) is equivalent to df %>% pivot_longer(c(x, y, z), names_to = "key", values_to = "value")"

With the advent of dplyr 1.1.0 it seemed prudent to ensure current syntax is reflected for new learners.